### PR TITLE
Mask DHCPCD service from starting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,9 @@ EOF
 cat > 01-run-chroot.sh <<EOF
 #!/bin/bash
 
+# Disable dhcpcd - it has a conflict with cloud-init network config
+systemctl mask dhcpcd
+
 cat > /etc/cloud/cloud.cfg <<EOC
 # The top level settings are used as module
 # and system configuration.


### PR DESCRIPTION
Fixes #1

DHCPCD and cloud-init both try to control the networking, it's a bad life choice to have two masters...

This solves the problem of getting an unrequested dynamic address, I'm now seeing,
```
rfkill: cannot open /dev/rfkill: Permission denied
rfkill: cannot read /dev/rfkill: Bad file descriptor
```
When I login over SSH, which I've isolated to `/etc/profile.d/wifi-check.sh` checking only that `/dev/rfkill` has the character attribute. I'm pretty sure that it can be fixed by also checking for write permission so I'm going to see if I can properly stitch that in as well now.